### PR TITLE
Reduce Rectangle Count

### DIFF
--- a/lib/prawn/qrcode.rb
+++ b/lib/prawn/qrcode.rb
@@ -89,12 +89,21 @@ module QRCode
 
       qr_code.modules.each_index do |row|
         pos_x = 4*dot
+        dark_col = 0
         qr_code.modules.each_index do |col|
           move_to [pos_x, pos_y]
           if qr_code.dark?(row, col)
-            fill { rectangle([pos_x, pos_y], dot, dot) }
+            dark_col = dark_col+1
+          else
+            if (dark_col>0)
+              fill { rectangle([pos_x - dark_col*dot, pos_y], dot*dark_col, dot) }
+              dark_col = 0
+            end
           end
           pos_x = pos_x + dot
+        end
+        if (dark_col > 0)
+          fill { rectangle([pos_x - dark_col*dot, pos_y], dot*dark_col, dot) }
         end
         pos_y = pos_y - dot
       end


### PR DESCRIPTION
This change reduces the rectangle count (and thus the size of the generated PDF) by joining contiguous rectangles within a single row. In the project where I'm using your library, this reduced the size of the generated PDF by 25%.

Note: I'm a Ruby neophite, so there may be a more "Ruby" way to accomplish the same thing. 
