### PR TITLE
Pass options to renderer

### DIFF
--- a/lib/prawn/qrcode.rb
+++ b/lib/prawn/qrcode.rb
@@ -56,7 +56,7 @@ module QRCode
       qr_code = RQRCode::QRCode.new(content, :size=>qr_version, :level=>level)
 
       dot_size = extent/(8+qr_code.modules.length) if extent
-      render_qr_code(qr_code, :dot=>dot_size, :pos=>opt[:pos], :stroke=>opt[:stroke], :align=>opt[:align])
+      render_qr_code(qr_code, opt.merge(:dot=>dot_size))
     rescue RQRCode::QRCodeRunTimeError
       if qr_version <40
         retry


### PR DESCRIPTION
By now we can pass options to`print_qr_code` but some are not working like `background_color`or `foreground_color` because they are not passed to the render call.
