### PR TITLE
fixing extent handling always overwriting dot_size

### DIFF
--- a/lib/prawn/qrcode.rb
+++ b/lib/prawn/qrcode.rb
@@ -49,13 +49,14 @@ module QRCode
     opt = options.extract_options!
     qr_version = 0
     level = opt[:level] || :m
-    extent = opt[:extent].to_f
+    extent = opt[:extent].nil? ? nil : opt[:extent].to_f
     dot_size = opt[:dot].to_f || DEFAULT_DOTSIZE
     begin
       qr_version +=1
       qr_code = RQRCode::QRCode.new(content, :size=>qr_version, :level=>level)
 
-      dot_size = extent/(8+qr_code.modules.length) if extent
+      dot_size = extent/(8+qr_code.modules.length) unless extent.nil?
+      
       render_qr_code(qr_code, opt.merge(:dot=>dot_size))
     rescue RQRCode::QRCodeRunTimeError
       if qr_version <40


### PR DESCRIPTION
Great job with the library, first of all!

I noticed that none of our codes were generating, and I tracked it down to dot_size always being set to zero, because if opts[:extent] is nil, nil to float evaluates as 0.0 and then "if extent" on line 58 always returns true, therefore always overwriting dot size.

I'm no PDF pro but this seems like a bug.