### PR TITLE
Fix Prawn::QRCode#print_qr_code

### DIFF
--- a/lib/prawn/qrcode.rb
+++ b/lib/prawn/qrcode.rb
@@ -74,7 +74,7 @@ module Prawn
     #
     def print_qr_code(content, level: :m, mode: nil, pos: [0, cursor], **options)
       qr_code = Prawn::QRCode.min_qrcode(content, level: level, mode: mode)
-      render_qr_code(qr_code, pos: pos, stroke: stroke, margin: margin, **options)
+      render_qr_code(qr_code, pos: pos, **options)
     end
 
     # Renders a prepared QR code (RQRCode::QRCode) int the pdf.

--- a/test/test_qrcode_in_context.rb
+++ b/test/test_qrcode_in_context.rb
@@ -1,0 +1,10 @@
+require 'minitest/autorun'
+require 'prawn/qrcode'
+require 'prawn/document'
+
+class TestQrcodeInContext < Minitest::Test
+  def test_render_with_margin
+    context = Prawn::Document.new
+    assert(context.print_qr_code('HELOWORLD', margin: 0))
+  end
+end


### PR DESCRIPTION
This calls the `Renderer` with a `margin` argument of `margin`. However,
`#margin` is not defined on the context of this instance method.

If I understand it correctly, this should pass on the `margin` option
from the options hash (same as with the `stroke` argument). This is
accomplished by the `**options` double splat at the end of the method
call.