### PR TITLE
Align before render

### DIFF
--- a/lib/prawn/qrcode.rb
+++ b/lib/prawn/qrcode.rb
@@ -166,11 +166,11 @@ module Prawn
         rlim = bounding_box.right
         case @align
         when :center
-          @point[0] = (rlim / 2) - (extent / 2)
+          @pos[0] = (rlim / 2) - (extent / 2)
         when :right
-          @point[0] = rlim - extent
+          @pos[0] = rlim - extent
         when :left
-          @point[0] = 0
+          @pos[0] = 0
         end
       end
 
@@ -178,6 +178,9 @@ module Prawn
       def render(pdf)
         pdf.fill_color background_color
 
+        pos(pdf) # make sure the @pos attribute is set before calling align
+        align(pdf.bounds)
+        
         pdf.bounding_box(pos(pdf), width: extent, height: extent) do |_box|
           pdf.fill_color foreground_color
           margin_dist = margin * dot

--- a/test/test_qrcode_in_context.rb
+++ b/test/test_qrcode_in_context.rb
@@ -7,4 +7,12 @@ class TestQrcodeInContext < Minitest::Test
     context = Prawn::Document.new
     assert(context.print_qr_code('HELOWORLD', margin: 0))
   end
+  def test_render_with_alignment
+  	context = Prawn::Document.new
+  	left = context.render_qr_code('HELLOWORLD', align: :left)
+  	center = context.render_qr_code('HELLOWORLD', align: :center)
+  	right = context.render_qr_code('HELLOWORLD', align: :right)
+  	assert(left.anchor[0] < center.anchor[0])
+  	assert(center.anchor[0] < right.anchor[0])
+  end
 end

--- a/test/test_qrcode_in_context.rb
+++ b/test/test_qrcode_in_context.rb
@@ -9,9 +9,9 @@ class TestQrcodeInContext < Minitest::Test
   end
   def test_render_with_alignment
   	context = Prawn::Document.new
-  	left = context.render_qr_code('HELLOWORLD', align: :left)
-  	center = context.render_qr_code('HELLOWORLD', align: :center)
-  	right = context.render_qr_code('HELLOWORLD', align: :right)
+  	left = context.print_qr_code('HELLOWORLD', align: :left)
+  	center = context.print_qr_code('HELLOWORLD', align: :center)
+  	right = context.print_qr_code('HELLOWORLD', align: :right)
   	assert(left.anchor[0] < center.anchor[0])
   	assert(center.anchor[0] < right.anchor[0])
   end


### PR DESCRIPTION
In version 0.4.0, you could pass the `render_qr_code` function an `:align` option with possible values `:left`, `:right`, `:center` and the qr code would be repositioned horizontally. 

This seems to no longer work as of version 0.5.0 because the re-alignment code is now handled in the new `Renderer` class. 

This PR restores the old behaviour so that passing an `:align` option to `render_qr_code` or `print_qr_code` will work as expected again.

Please let me know if you would like additional tests/changes added to this PR. 