### PR TITLE
Reduce number of dependencies

### DIFF
--- a/prawn-qrcode.gemspec
+++ b/prawn-qrcode.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
 END_DESC
 
   spec.add_dependency('prawn', '>=1')
-  spec.add_dependency('rqrcode', '>=1.0.0')
+  spec.add_dependency('rqrcode_core')
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rubygems-tasks', '~> 0.2.5'


### PR DESCRIPTION
Only features from rqrcode_core are used by this gem. With this change it stops including 2 other gems in the bundle: chunky_png and rqrcode.
The dependency version was just removed to be backward compatible. It will match previous expectations to rqrcode restrictions.
