### PR TITLE
reduce number of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ gem install prawn-qrcode
 require 'prawn/qrcode'
 
 qrcode_content = "http://github.com/jabbrwcky/prawn-qrcode"
-qrcode = RQRCode::QRCode.new(qrcode_content, level: :h, size: 5)
+qrcode = RQRCodeCore::QRCode.new(qrcode_content, level: :h, size: 5)
 
 # Render a prepared QRCode at he cursor position
 # using a default module (e.g. dot) size of 1pt or 1/72 in

--- a/examples/prepared_qrcode.rb
+++ b/examples/prepared_qrcode.rb
@@ -15,7 +15,7 @@ require 'rubygems'
 require 'prawn'
 require_relative '../lib/prawn/qrcode'
 
-qrcode = RQRCode::QRCode.new('https://github.com/jabbrwcky/prawn-qrcode', size: 5)
+qrcode = RQRCodeCore::QRCode.new('https://github.com/jabbrwcky/prawn-qrcode', size: 5)
 
 Prawn::Document.new(page_size: 'A4') do
   text 'Prawn QR Code sample 1: Predefined QR-Code'

--- a/lib/prawn/qrcode.rb
+++ b/lib/prawn/qrcode.rb
@@ -14,7 +14,7 @@
 #  limitations under the License.
 #++
 require 'prawn'
-require 'rqrcode'
+require 'rqrcode_core'
 
 # :title: Prawn/QRCode
 #
@@ -38,13 +38,13 @@ module Prawn
     # @param [symbol] level Optional Error correction level to use. One of: (:l, :m, :h, :q), Defaults to :m
     # @param [symbol] mode Optional mode. One of (:number, :alphanumeric, :byte_8bit, :kanji), Defaults to :alphanumeric or :byte_8bit
     #
-    # @return [RQRCode::QRCode] QR code that can hold the specified data with the desired error correction level
+    # @return [RQRCodeCore::QRCode] QR code that can hold the specified data with the desired error correction level
     #
     # @raise [RQRCodeCore::QRCodeRunTimeError] if the data specified will not fit in the largest QR code (QR version 40) with the given error correction level
     #
     def self.min_qrcode(content, qr_version = 0, level: :m, mode: nil, **)
       qr_version += 1
-      RQRCode::QRCode.new(content, size: qr_version, level: level, mode: mode)
+      RQRCodeCore::QRCode.new(content, size: qr_version, level: level, mode: mode)
     rescue RQRCodeCore::QRCodeRunTimeError
       retry if qr_version < 40
       raise
@@ -53,7 +53,7 @@ module Prawn
     # dotsize calculates the required dotsize for a QR code to be rendered with the given extent and the module size
     # @since 0.5.0
     #
-    # @param [RQRCode::QRCode] qr_code QR code to render
+    # @param [RQRCodeCore::QRCode] qr_code QR code to render
     # @param [Integer/Float] extent Size of QR code given in pt (1 pt == 1/72 in)
     # @param [Integer] margin Width of margin as number of modules (defaults to 4 modules)
     #
@@ -77,10 +77,10 @@ module Prawn
       render_qr_code(qr_code, pos: pos, **options)
     end
 
-    # Renders a prepared QR code (RQRCode::QRCode) int the pdf.
+    # Renders a prepared QR code (RQRCodeCore::QRCode) int the pdf.
     # @since 0.5.0
     #
-    # @param [RQRCode::QRCode] qr_code The QR code (an RQRCode::QRCode) to render
+    # @param [RQRCodeCore::QRCode] qr_code The QR code (an RQRCodeCore::QRCode) to render
     # @param [Hash] options additional options that are passed on to Prawn::QRCode::Renderer
     #
     # @see Renderer
@@ -104,7 +104,7 @@ module Prawn
 
       # creates a new renderer for the given QR code
       #
-      # @param qr_code [RQRCode::QRCode] QR code to render
+      # @param qr_code [RQRCodeCore::QRCode] QR code to render
       # @param [Hash] options additional options
       # @option options [Float] :dot size of a dot in pt (1/72 in)
       # @option options [Array] :pos Two-element array containing the position at which the QR-Code should be rendered. Defaults to [0,cursor]
@@ -180,7 +180,7 @@ module Prawn
 
         pos(pdf) # make sure the @pos attribute is set before calling align
         align(pdf.bounds)
-        
+
         pdf.bounding_box(pos(pdf), width: extent, height: extent) do |_box|
           pdf.fill_color foreground_color
           margin_dist = margin * dot
@@ -195,7 +195,7 @@ module Prawn
 
             row.each_index do |col|
               pdf.move_to [pos_x, pos_y]
-              if qr_code.qrcode.checked?(index, col)
+              if qr_code.checked?(index, col)
                 dark_col += 1
               else
                 if dark_col > 0

--- a/lib/prawn/qrcode/table.rb
+++ b/lib/prawn/qrcode/table.rb
@@ -8,7 +8,7 @@ module Prawn
       #
       # @param [Hash] options for creating table cell
       # @option [String] :content string content to render as QR code
-      # @option [RQRCode::QRCode] :qr_code qr_code object to render
+      # @option [RQRCodeCore::QRCode] :qr_code qr_code object to render
       # @option [Prawn::QRCode::Renderer] :renderer initialized renderer (contains qr_code)
       #
       # The table cell will create a QRCode and Renderer on demand, all necessary options will be passed through

--- a/prawn-qrcode.gemspec
+++ b/prawn-qrcode.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
 END_DESC
 
   spec.add_dependency('prawn', '>=1')
-  spec.add_dependency('rqrcode', '>=1.0.0')
+  spec.add_dependency('rqrcode_core')
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rubygems-tasks', '~> 0.2.5'


### PR DESCRIPTION
Only features from rqrcode_core are used by this gem. With this change it stops including 2 other gems in the bundle: chunky_png and rqrcode.
The dependency version was just removed to be backward compatible. It will match previous expectations to rqrcode restrictions.
